### PR TITLE
Add shebang-interpreter directive

### DIFF
--- a/test/example1/nekpmpi
+++ b/test/example1/nekpmpi
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -f logfile
 mv $1.log.$2 $1.log1.$2
 mpiexec -np $2 ./nekbone $1 > $1.log.$2

--- a/test/example2/nekpmpi
+++ b/test/example2/nekpmpi
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -f logfile
 mv $1.log.$2 $1.log1.$2
 mpiexec -np $2 ./nekbone $1 > $1.log.$2

--- a/test/example3/nekpmpi
+++ b/test/example3/nekpmpi
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -f logfile
 mv $1.log.$2 $1.log1.$2
 mpiexec -np $2 ./nekbone $1 > $1.log.$2

--- a/test/nek_comm/nekpmpi
+++ b/test/nek_comm/nekpmpi
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -f logfile
 mv $1.log.$2 $1.log1.$2
 mpiexec -np $2 ./nekbone $1 > $1.log.$2

--- a/test/nek_delay/nekpmpi
+++ b/test/nek_delay/nekpmpi
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -f logfile
 mv $1.log.$2 $1.log1.$2
 mpiexec -np $2 ./nekbone $1 > $1.log.$2

--- a/test/nek_mgrid/nekpmpi
+++ b/test/nek_mgrid/nekpmpi
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -f logfile
 mv $1.log.$2 $1.log1.$2
 mpiexec -np $2 ./nekbone $1 > $1.log.$2


### PR DESCRIPTION
Otherwise paths in the script (e.g., `./nekbone`) are resolved
relative to where the script is stored, not relative to where
it is called. Latter property is important for `spack` packaging.